### PR TITLE
Friendlier for development environments

### DIFF
--- a/config.inc.php
+++ b/config.inc.php
@@ -8,12 +8,29 @@ if (!isset($_ENV['MYSQL_HOST']) && isset($_ENV['MYSQL_PORT_3306_TCP_ADDR'])) {
 $hosts = isset($_ENV['MYSQL_HOST']) ? $_ENV['MYSQL_HOST'] : 'mysql';
 foreach (explode(',', $hosts) as $index => $host) {
 	$config = &$cfg['Servers'][$index + 1];
-	$host   = trim($host);
+
+	// split into host[:port], user and pass
+	$parts = explode(";", $host);
+
+	$host = trim(array_shift($parts));
 	if (strpos($host, ':') !== false) {
 		list($host, $port) = explode(':', $host);
 		$config['port'] = $port;
 	}
-	$config['host']            = $host;
+	$config['host'] = $host;
+
+	if(!empty($parts)) {
+		$user   = trim(array_shift($parts));
+		$config['user'] = $user;
+	}
+
+	if(!empty($parts)) {
+		$user   = trim(join(";",$parts));
+		$config['auth_type'] = 'config';
+		$config['password'] = $user;
+	}
+
+
 	$config['AllowNoPassword'] = true;
 }
 
@@ -41,3 +58,10 @@ if (!file_exists($file_with_secret)) {
 }
 
 include $file_with_secret;
+
+if (isset($_ENV['PMA_CONFIG'])) {
+	$custom = json_decode($_ENV['PMA_CONFIG'], true);
+
+	$cfg = array_merge($cfg, $custom);
+}
+

--- a/config.inc.php
+++ b/config.inc.php
@@ -10,22 +10,21 @@ foreach (explode(',', $hosts) as $index => $host) {
 	$config = &$cfg['Servers'][$index + 1];
 
 	// split into host[:port], user and pass
-	$parts = explode(";", $host);
+	list($host, $user, $password) = explode(';', $host, 3) + [1 => '', 2 => ''];
 
-	$host = trim(array_shift($parts));
 	if (strpos($host, ':') !== false) {
-		list($host, $port) = explode(':', $host);
+		list($host, $port) = explode(':', trim($host));
 		$config['port'] = $port;
 	}
 	$config['host'] = $host;
 
-	if(!empty($parts)) {
-		$config['user'] = trim(array_shift($parts));
+	if($user) {
+		$config['user'] = trim($user);
 	}
 
-	if(!empty($parts)) {
+	if($password) {
 		$config['auth_type'] = 'config';
-		$config['password'] = trim(join(";", $parts)); // Passwords can contain ; so merge any remaining parts
+		$config['password'] = trim($password);
 	}
 
 
@@ -57,8 +56,8 @@ if (!file_exists($file_with_secret)) {
 
 include $file_with_secret;
 
-if (isset($_ENV['PMA_CONFIG'])) {
-	$custom = json_decode($_ENV['PMA_CONFIG'], true);
+if (isset($_ENV['JSON_CONFIG'])) {
+	$custom = json_decode($_ENV['JSON_CONFIG'], true);
 
 	$cfg = array_merge($cfg, $custom);
 }

--- a/config.inc.php
+++ b/config.inc.php
@@ -13,22 +13,23 @@ foreach (explode(',', $hosts) as $index => $host) {
 	list($host, $user, $password) = explode(';', $host, 3) + [1 => '', 2 => ''];
 
 	if (strpos($host, ':') !== false) {
-		list($host, $port) = explode(':', trim($host));
+		list($host, $port) = explode(':', $host);
 		$config['port'] = $port;
 	}
 	$config['host'] = $host;
 
 	if($user) {
-		$config['user'] = trim($user);
+		$config['user'] = $user;
 	}
 
 	if($password) {
 		$config['auth_type'] = 'config';
-		$config['password'] = trim($password);
+		$config['password'] = $password;
 	}
 
-
 	$config['AllowNoPassword'] = true;
+
+	$config = array_map('trim', $config);
 }
 
 if (isset($_ENV['ALLOW_ARBITRARY'])) {

--- a/config.inc.php
+++ b/config.inc.php
@@ -20,14 +20,12 @@ foreach (explode(',', $hosts) as $index => $host) {
 	$config['host'] = $host;
 
 	if(!empty($parts)) {
-		$user   = trim(array_shift($parts));
-		$config['user'] = $user;
+		$config['user'] = trim(array_shift($parts));
 	}
 
 	if(!empty($parts)) {
-		$user   = trim(join(";",$parts));
 		$config['auth_type'] = 'config';
-		$config['password'] = $user;
+		$config['password'] = trim(join(";", $parts)); // Passwords can contain ; so merge any remaining parts
 	}
 
 

--- a/readme.md
+++ b/readme.md
@@ -59,9 +59,9 @@ docker run --rm --link mysql:mysql -p 1234:80 -e ABSOLUTE_URI=https://domain.tld
 ```
 
 # Custom phpMyAdmin settings
-You can specify any PMA-config-setting using a JSON object passed to `PMA_CONFIG`, that will be merged to the existing config.
+You can specify any PMA-config-setting using a JSON object passed to `JSON_CONFIG`, that will be merged to the existing config.
 ```bash
-docker run --rm --link mysql:mysql -p 1234:80 -e PMA_CONFIG='{"AllowUserDropDatabase": true,"MaxTableList": 450, "NavigationTreeTableSeparator": "_"}' nazarpc/phpmyadmin
+docker run --rm --link mysql:mysql -p 1234:80 -e JSON_CONFIG='{"AllowUserDropDatabase": true,"MaxTableList": 450, "NavigationTreeTableSeparator": "_"}' nazarpc/phpmyadmin
 ```
 
 # Difference from other similar images with phpMyAdmin

--- a/readme.md
+++ b/readme.md
@@ -42,7 +42,10 @@ docker run --rm --link mysql:mysql -p 1234:80 -e MYSQL_HOST=mariadb:9999 nazarpc
 Examples of valid `MYSQL_HOST`:
 * `mariadb` - hostname `mariadb`
 * `mariadb:9999` - hostname `mariadb` with port `9999`
-* `mysql, mariadb:9999` - multiple servers
+* `mariadb;root` - hostname `mariadb` with user `root`
+* `mariadb;root;123` - hostname `mariadb` with user `root` & password `123`
+* `mariadb:9999;root;123` - hostname `mariadb` with user `root`, password `123` & port `9999`
+* `mysql, mariadb:9999, mariadb:9999;root;123` - multiple servers
 
 # Allow connecting to arbitrary MySQL host
 ```bash
@@ -53,6 +56,12 @@ docker run --rm --link mysql:mysql -p 1234:80 -e ALLOW_ARBITRARY=1 nazarpc/phpmy
 Sometimes phpMyAdmin may determine its own URI incorrectly. Usually you can fix it by correcting virtual host of revers proxy,  but sometimes it might be useful to specify URI explicitly:
 ```bash
 docker run --rm --link mysql:mysql -p 1234:80 -e ABSOLUTE_URI=https://domain.tld/phpmyadmin nazarpc/phpmyadmin
+```
+
+# Custom phpMyAdmin settings
+You can specify any PMA-config-setting using a JSON object passed to `PMA_CONFIG`, that will be merged to the existing config.
+```bash
+docker run --rm --link mysql:mysql -p 1234:80 -e PMA_CONFIG='{"AllowUserDropDatabase": true,"MaxTableList": 450, "NavigationTreeTableSeparator": "_"}' nazarpc/phpmyadmin
 ```
 
 # Difference from other similar images with phpMyAdmin


### PR DESCRIPTION
Can now specify username and password for hosts, so you don't have to log in during local development.

Can also set all available config-settings with json.