### PR TITLE
Make image ready for OpenShift container platform

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -26,7 +26,12 @@ RUN PHPMYADMIN_VERSION=4.8.3 && \
 COPY .htaccess /var/www/html/.htaccess
 COPY config.inc.php /var/www/html/config.inc.php
 
+# Enable the container to be run by OpenShift with a non-privileged user. For details see
+# https://docs.openshift.com/container-platform/3.7/creating_images/guidelines.html#use-uid
+
+RUN chgrp -R 0 /tmp /var/run/apache2 /var/www/html && \
+	chmod -R g=u /tmp /var/run/apache2 /var/www/html
+
 COPY docker-entrypoint.sh /home/entrypoint.sh
 
 ENTRYPOINT ["/home/entrypoint.sh"]
-

--- a/docker-entrypoint.sh
+++ b/docker-entrypoint.sh
@@ -4,6 +4,11 @@
 
 set -e
 
+# Support for Apache web server custom ports: env vars HTTP_PORT (80) and HTTPS_PORT (443)
+
+test -z $HTTP_PORT || sed -i "s/Listen 80/Listen $HTTP_PORT/" /etc/apache2/ports.conf
+test -z $HTTPS_PORT || sed -i "s/Listen 443/Listen $HTTPS_PORT/" /etc/apache2/ports.conf
+
 # Support for UPLOAD_SIZE env var, if specified - will be used instead of default value 128M
 
 test -z $UPLOAD_SIZE || sed -i "s/128M/$UPLOAD_SIZE/g" /var/www/html/.htaccess

--- a/readme.md
+++ b/readme.md
@@ -6,7 +6,7 @@ This container may be used with MySQL or MariaDB linked containers.
 
 If you like this image - you may also like set of images for [WebServer](https://github.com/nazar-pc/docker-webserver).
 
-#How to use
+# How to use
 With MySQL:
 ```bash
 docker run --name mysql -e MYSQL_ROOT_PASSWORD=my_password -d mysql
@@ -22,19 +22,19 @@ docker run --rm --link mariadb:mysql -p 1234:80 nazarpc/phpmyadmin
 
 After these commands you'll be able to access phpMyAdmin via `http://localhost:1234`, press `Ctrl+C` to stop container, and it will be removed automatically (because of `--rm` option). Feel free to change `1234` to any port you like.
 
-# Specify allowed upload file size
+## Specify allowed upload file size
 Sometimes it is necessary to upload big dump which doesn't fit into default limit 128M. You can specify alternative size via environment variable `UPLOAD_SIZE`:
 ```bash
 docker run --rm --link mysql:mysql -p 1234:80 -e UPLOAD_SIZE=1G nazarpc/phpmyadmin
 ```
 
-# Increase session timeout
+## Increase session timeout
 The default session timeout is just 1440 seconds (24 minutes). You can specify an alternative timeout by setting the environment variable `SESSION_TIMEOUT`:
 ```bash
 docker run --rm --link mysql:mysql -p 1234:80 -e SESSION_TIMEOUT=86400 nazarpc/phpmyadmin
 ```
 
-# Customize host name
+## Customize host name
 By default phpMyAdmin assumes MySQL is available through `mysql` hostname. Sometimes this is not the case, so you can override this with environmental variable `MYSQL_HOST`:
 ```bash
 docker run --rm --link mysql:mysql -p 1234:80 -e MYSQL_HOST=mariadb:9999 nazarpc/phpmyadmin
@@ -47,25 +47,31 @@ Examples of valid `MYSQL_HOST`:
 * `mariadb:9999;root;123` - hostname `mariadb` with user `root`, password `123` & port `9999`
 * `mysql, mariadb:9999, mariadb:9999;root;123` - multiple servers
 
-# Allow connecting to arbitrary MySQL host
+## Allow connecting to arbitrary MySQL host
 ```bash
 docker run --rm --link mysql:mysql -p 1234:80 -e ALLOW_ARBITRARY=1 nazarpc/phpmyadmin
 ```
 
-# Custom URI of phpMyAdmin instance
+## Custom URI of phpMyAdmin instance
 Sometimes phpMyAdmin may determine its own URI incorrectly. Usually you can fix it by correcting virtual host of revers proxy,  but sometimes it might be useful to specify URI explicitly:
 ```bash
 docker run --rm --link mysql:mysql -p 1234:80 -e ABSOLUTE_URI=https://domain.tld/phpmyadmin nazarpc/phpmyadmin
 ```
 
-# Custom phpMyAdmin settings
+## Custom phpMyAdmin settings
 You can specify any PMA-config-setting using a JSON object passed to `JSON_CONFIG`, that will be merged to the existing config.
 ```bash
 docker run --rm --link mysql:mysql -p 1234:80 -e JSON_CONFIG='{"AllowUserDropDatabase": true,"MaxTableList": 450, "NavigationTreeTableSeparator": "_"}' nazarpc/phpmyadmin
 ```
 
+## Custom ports for HTTP and HTTPS inside the container
+If you need Apache to listen on ports other than the default 80 and 443 (e.g. when running the container with a non-privileged user) specify alternative values via the environment variables `HTTP_PORT` and `HTTPS_PORT`:
+```bash
+docker run --rm --link mysql:mysql --user 1001 -p 8080 -p 4443 -e HTTP_PORT=8080 -e HTTPS_PORT=4443 nazarpc/phpmyadmin
+```
+
 # Difference from other similar images with phpMyAdmin
-This image doesn't use any custom base, just official PHP 5.6 container with built-in Apache2 web server.
+This image doesn't use any custom base, just official PHP 7.2 container with built-in Apache2 web server.
 There is support for importing SQL dumps in all compression formats supported by phpMyAdmin.
 There is possibility to connect to multiple servers of your choice or even to arbitrary servers if necessary.
 
@@ -73,8 +79,10 @@ Also this image generates `blowfish_secret` configuration option (unique for eac
 
 Plus, I'll try to keep it up to date with new releases of phpMyAdmin (as well as PHP itself and other software inside image), so, by using `nazarpc/phpmyadmin` image you'll always have latest versions.
 
-#Questions?
-Open an issue and ask your question there:)
+**Note:** This image is ready for running on OpenShift, which runs the container using a non-privileged user. You'll need to specify unprivileged ports for Apache (see above).
 
-#License
+# Questions?
+Open an [issue](https://github.com/nazar-pc/docker-phpmyadmin/issues) and ask your question there.
+
+# License
 Public Domain


### PR DESCRIPTION
These changes make the image ready for the [OpenShift container platform](https://www.openshift.com/), which runs containers with an unprivileged user (to avoid privileged access to the host machine).

New environment variables:
- `HTTP_PORT` (default: 80)
- `HTTPS_PORT` (default: 443)

Closes #21.