### PR TITLE
Allow entrypoint to edit files in /etc/apache2

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -29,9 +29,8 @@ COPY config.inc.php /var/www/html/config.inc.php
 # Enable the container to be run by OpenShift with a non-privileged user. For details see
 # https://docs.openshift.com/container-platform/3.7/creating_images/guidelines.html#use-uid
 
-RUN chgrp -R 0 /tmp /var/run/apache2 /var/www/html && \
-	chmod -R g=u /tmp /var/run/apache2 /var/www/html && \
-	chmod -R g=u /etc/apache2/ports.conf
+RUN chgrp -R 0 /tmp /etc/apache2 /var/run/apache2 /var/www/html && \
+	chmod -R g=u /tmp /etc/apache2 /var/run/apache2 /var/www/html
 
 COPY docker-entrypoint.sh /home/entrypoint.sh
 

--- a/readme.md
+++ b/readme.md
@@ -67,7 +67,7 @@ docker run --rm --link mysql:mysql -p 1234:80 -e JSON_CONFIG='{"AllowUserDropDat
 ## Custom ports for HTTP and HTTPS inside the container
 If you need Apache to listen on ports other than the default 80 and 443 (e.g. when running the container with a non-privileged user) specify alternative values via the environment variables `HTTP_PORT` and `HTTPS_PORT`:
 ```bash
-docker run --rm --link mysql:mysql --user 1001 -p 8080 -p 4443 -e HTTP_PORT=8080 -e HTTPS_PORT=4443 nazarpc/phpmyadmin
+docker run --rm --user 1001 -p 8080:8080 -p 4443:4443 -e HTTP_PORT=8080 -e HTTPS_PORT=4443 nazarpc/phpmyadmin
 ```
 
 # Difference from other similar images with phpMyAdmin


### PR DESCRIPTION
Fixes permission issues: Entrypoint script can now edit files in `/etc/apche2`.

Sorry for the inconvenience in PR #22! -- I now verified the changes locally.